### PR TITLE
Improve UI with chat style

### DIFF
--- a/client/components/ChatLog.jsx
+++ b/client/components/ChatLog.jsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+export default function ChatLog({ messages }) {
+  return (
+    <div className="flex flex-col gap-3 p-4 overflow-y-auto">
+      {messages.map((msg, idx) => (
+        <div
+          key={idx}
+          className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
+        >
+          <div
+            className={`max-w-xs px-4 py-2 rounded-2xl whitespace-pre-line ${
+              msg.role === "user"
+                ? "bg-blue-500 text-white rounded-br-none"
+                : "bg-gray-200 text-black rounded-bl-none"
+            }`}
+          >
+            {msg.text}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/client/components/SessionControls.jsx
+++ b/client/components/SessionControls.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { CloudLightning, CloudOff, MessageSquare } from "react-feather";
+import { CloudLightning, CloudOff, MessageSquare, Mic } from "react-feather";
 import Button from "./Button";
 
 function SessionStopped({ startSession }) {
@@ -34,7 +34,14 @@ function SessionActive({ stopSession, sendTextMessage }) {
   }
 
   return (
-    <div className="flex items-center justify-center w-full h-full gap-4">
+    <div className="flex items-center gap-2 w-full h-full">
+      <button
+        className="p-3 bg-gray-200 rounded-full"
+        onClick={stopSession}
+        title="disconnect"
+      >
+        <CloudOff height={18} />
+      </button>
       <input
         onKeyDown={(e) => {
           if (e.key === "Enter" && message.trim()) {
@@ -42,25 +49,25 @@ function SessionActive({ stopSession, sendTextMessage }) {
           }
         }}
         type="text"
-        placeholder="send a text message..."
-        className="border border-gray-200 rounded-full p-4 flex-1"
+        placeholder="Type a message..."
+        className="border border-gray-200 rounded-full p-3 flex-1"
         value={message}
         onChange={(e) => setMessage(e.target.value)}
       />
-      <Button
+      <button
+        className="p-3 bg-blue-500 text-white rounded-full"
         onClick={() => {
           if (message.trim()) {
             handleSendClientEvent();
           }
         }}
-        icon={<MessageSquare height={16} />}
-        className="bg-blue-400"
+        title="send"
       >
-        send text
-      </Button>
-      <Button onClick={stopSession} icon={<CloudOff height={16} />}>
-        disconnect
-      </Button>
+        <MessageSquare height={18} />
+      </button>
+      <button className="p-3 bg-gray-200 rounded-full" title="mic">
+        <Mic height={18} />
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- create `ChatLog` to show message bubbles
- update `App` to manage chat history and display `ChatLog`
- restyle `SessionControls` to resemble ChatGPT voice interface

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_6877f254e7448333889b42872d8e7e3b