### PR TITLE
Improve UI with chat style

### DIFF
--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -8,6 +8,8 @@ export default function App() {
   const [isSessionActive, setIsSessionActive] = useState(false);
   const [events, setEvents] = useState([]);
   const [messages, setMessages] = useState([]);
+  const [assistantStream, setAssistantStream] = useState("");
+  const [userStream, setUserStream] = useState("");
   const assistantBuffer = useRef("");
   const userBuffer = useRef("");
   const [dataChannel, setDataChannel] = useState(null);
@@ -145,6 +147,7 @@ export default function App() {
             event.response.output.forEach((out) => {
               if (out.type === "text") {
                 assistantBuffer.current += out.text;
+                setAssistantStream(assistantBuffer.current.trim());
               }
             });
           }
@@ -159,6 +162,7 @@ export default function App() {
               },
             ]);
             assistantBuffer.current = "";
+            setAssistantStream("");
           }
         }
 
@@ -166,6 +170,7 @@ export default function App() {
         if (event.type && event.type.startsWith("transcript")) {
           if (event.transcript && event.transcript.text) {
             userBuffer.current += event.transcript.text;
+            setUserStream(userBuffer.current.trim());
           }
 
           if (event.type === "transcript.done" && userBuffer.current) {
@@ -178,6 +183,7 @@ export default function App() {
               },
             ]);
             userBuffer.current = "";
+            setUserStream("");
           }
         }
 
@@ -189,6 +195,8 @@ export default function App() {
         setIsSessionActive(true);
         setEvents([]);
         setMessages([]);
+        setAssistantStream("");
+        setUserStream("");
       });
     }
   }, [dataChannel]);
@@ -203,7 +211,11 @@ export default function App() {
       <main className="absolute top-16 left-0 right-0 bottom-0">
         <section className="absolute inset-0 flex flex-col">
           <div className="flex-1 overflow-y-auto">
-            <ChatLog messages={messages} />
+            <ChatLog
+              messages={messages}
+              userStream={userStream}
+              assistantStream={assistantStream}
+            />
           </div>
           <div className="h-32 p-4">
             <SessionControls

--- a/client/components/ChatLog.jsx
+++ b/client/components/ChatLog.jsx
@@ -1,9 +1,9 @@
 import React from "react";
 
-export default function ChatLog({ messages }) {
+export default function ChatLog({ messages, userStream, assistantStream }) {
   return (
     <div className="flex flex-col gap-3 p-4 overflow-y-auto">
-      {messages.length === 0 ? (
+      {messages.length === 0 && !userStream && !assistantStream ? (
         <p className="text-gray-400 text-sm">Start talking to begin...</p>
       ) : (
         messages.map((msg) => (
@@ -22,6 +22,22 @@ export default function ChatLog({ messages }) {
             </div>
           </div>
         ))
+      )}
+
+      {userStream && (
+        <div className="flex justify-end">
+          <div className="max-w-xs px-4 py-2 rounded-2xl bg-blue-500 text-white rounded-br-none opacity-70 whitespace-pre-line">
+            {userStream}
+          </div>
+        </div>
+      )}
+
+      {assistantStream && (
+        <div className="flex justify-start">
+          <div className="max-w-xs px-4 py-2 rounded-2xl bg-gray-200 text-black rounded-bl-none opacity-70 whitespace-pre-line">
+            {assistantStream}
+          </div>
+        </div>
       )}
     </div>
   );

--- a/client/components/ChatLog.jsx
+++ b/client/components/ChatLog.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+export default function ChatLog({ messages }) {
+  return (
+    <div className="flex flex-col gap-3 p-4 overflow-y-auto">
+      {messages.length === 0 ? (
+        <p className="text-gray-400 text-sm">Start talking to begin...</p>
+      ) : (
+        messages.map((msg) => (
+          <div
+            key={msg.id}
+            className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
+          >
+            <div
+              className={`max-w-xs px-4 py-2 rounded-2xl whitespace-pre-line ${
+                msg.role === "user"
+                  ? "bg-blue-500 text-white rounded-br-none"
+                  : "bg-gray-200 text-black rounded-bl-none"
+              }`}
+            >
+              {msg.text}
+            </div>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}

--- a/client/components/SessionControls.jsx
+++ b/client/components/SessionControls.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { CloudLightning, CloudOff, MessageSquare } from "react-feather";
+import { CloudLightning, CloudOff, MessageSquare, Mic } from "react-feather";
 import Button from "./Button";
 
 function SessionStopped({ startSession }) {
@@ -34,7 +34,14 @@ function SessionActive({ stopSession, sendTextMessage }) {
   }
 
   return (
-    <div className="flex items-center justify-center w-full h-full gap-4">
+    <div className="flex items-center gap-2 w-full h-full">
+      <button
+        className="p-3 bg-gray-200 rounded-full"
+        onClick={stopSession}
+        title="disconnect"
+      >
+        <CloudOff height={18} />
+      </button>
       <input
         onKeyDown={(e) => {
           if (e.key === "Enter" && message.trim()) {
@@ -42,25 +49,25 @@ function SessionActive({ stopSession, sendTextMessage }) {
           }
         }}
         type="text"
-        placeholder="send a text message..."
-        className="border border-gray-200 rounded-full p-4 flex-1"
+        placeholder="Type a message..."
+        className="border border-gray-200 rounded-full p-3 flex-1"
         value={message}
         onChange={(e) => setMessage(e.target.value)}
       />
-      <Button
+      <button
+        className="p-3 bg-blue-500 text-white rounded-full"
         onClick={() => {
           if (message.trim()) {
             handleSendClientEvent();
           }
         }}
-        icon={<MessageSquare height={16} />}
-        className="bg-blue-400"
+        title="send"
       >
-        send text
-      </Button>
-      <Button onClick={stopSession} icon={<CloudOff height={16} />}>
-        disconnect
-      </Button>
+        <MessageSquare height={18} />
+      </button>
+      <button className="p-3 bg-gray-200 rounded-full" title="mic">
+        <Mic height={18} />
+      </button>
     </div>
   );
 }

--- a/client/components/SessionControls.jsx
+++ b/client/components/SessionControls.jsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
-import { CloudLightning, CloudOff, MessageSquare, Mic } from "react-feather";
-import Button from "./Button";
+import { CloudOff, MessageSquare, Mic } from "react-feather";
 
 function SessionStopped({ startSession }) {
   const [isActivating, setIsActivating] = useState(false);
@@ -14,13 +13,14 @@ function SessionStopped({ startSession }) {
 
   return (
     <div className="flex items-center justify-center w-full h-full">
-      <Button
+      <button
+        className="p-3 bg-blue-500 text-white rounded-full"
         onClick={handleStartSession}
-        className={isActivating ? "bg-gray-600" : "bg-red-600"}
-        icon={<CloudLightning height={16} />}
+        title="start session"
+        disabled={isActivating}
       >
-        {isActivating ? "starting session..." : "start session"}
-      </Button>
+        <Mic height={18} />
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- create `ChatLog` to show message bubbles
- update `App` to manage chat history and display `ChatLog`
- restyle `SessionControls` to resemble ChatGPT voice interface
- show transcripts from both the user and assistant in `ChatLog`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_6877f254e7448333889b42872d8e7e3b