### PR TITLE
Add mic toggle support

### DIFF
--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -12,6 +12,7 @@ export default function App() {
   const [messages, setMessages] = useState([]);
   const [assistantStream, setAssistantStream] = useState("");
   const [userStream, setUserStream] = useState("");
+  const [localStream, setLocalStream] = useState(null);
   const assistantBuffer = useRef("");
   const userBuffer = useRef("");
   const [dataChannel, setDataChannel] = useState(null);
@@ -31,6 +32,7 @@ export default function App() {
     const ms = await navigator.mediaDevices.getUserMedia({
       audio: true,
     });
+    setLocalStream(ms);
     pc.addTrack(ms.getTracks()[0]);
 
     const dc = pc.createDataChannel("oai-events");
@@ -76,6 +78,7 @@ export default function App() {
 
     setIsSessionActive(false);
     setDataChannel(null);
+    setLocalStream(null);
     peerConnection.current = null;
   }
 
@@ -129,7 +132,6 @@ export default function App() {
           event.timestamp = new Date().toLocaleTimeString();
         }
 
-main
         if (event.type && event.type.startsWith("response")) {
           if (event.response && event.response.output) {
             event.response.output.forEach((out) => {
@@ -205,6 +207,7 @@ main
             stopSession={stopSession}
             sendTextMessage={sendTextMessage}
             isSessionActive={isSessionActive}
+            localStream={localStream}
           />
         </div>
       </main>

--- a/client/components/SessionControls.jsx
+++ b/client/components/SessionControls.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { CloudOff, MessageSquare, Mic, CloudLightning, MicOff } from "react-feather";
 import Button from "./Button"; 
 
@@ -25,10 +25,21 @@ function SessionStopped({ startSession }) {
   );
 }
 
-function SessionActive({ stopSession, sendTextMessage }) {
+function SessionActive({ stopSession, sendTextMessage, localStream }) {
   const [message, setMessage] = useState("");
   const [isMicOn, setIsMicOn] = useState(true); //assuming mic is on by default
   const streamRef = useRef(null);
+
+  // keep reference to the current microphone stream
+  useEffect(() => {
+    streamRef.current = localStream;
+    if (localStream) {
+      const track = localStream.getAudioTracks()[0];
+      if (track) {
+        setIsMicOn(track.enabled);
+      }
+    }
+  }, [localStream]);
 
   function handleSendClientEvent() {
     sendTextMessage(message);
@@ -96,6 +107,7 @@ export default function SessionControls({
   stopSession,
   sendTextMessage,
   isSessionActive,
+  localStream,
 }) {
   return (
     <div className="flex gap-4 border-t-2 border-gray-200 h-full rounded-md">
@@ -103,6 +115,7 @@ export default function SessionControls({
         <SessionActive
           stopSession={stopSession}
           sendTextMessage={sendTextMessage}
+          localStream={localStream}
         />
       ) : (
         <SessionStopped startSession={startSession} />


### PR DESCRIPTION
## Summary
- hold on to local mic stream in `App`
- wire mic stream into `SessionControls` and toggle track enabled state

## Testing
- `npm run lint` *(fails: resolve not used and other errors)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687abd2b45848333922f01dd8dfe4fc3